### PR TITLE
Maintenance for MediaWiki 1.37

### DIFF
--- a/RemoveRedlinks/extension.json
+++ b/RemoveRedlinks/extension.json
@@ -8,7 +8,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "parser",
 	"requires": {
-		"MediaWiki": ">= 1.32.0"
+		"MediaWiki": ">= 1.34.0"
 	},
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\RemoveRedlinks\\": "includes/"

--- a/RemoveRedlinks/includes/Hooks.php
+++ b/RemoveRedlinks/includes/Hooks.php
@@ -16,6 +16,8 @@
 
 namespace MediaWiki\Extension\RemoveRedlinks;
 
+use RequestContext;
+
 class Hooks {
 
 	public static function onHtmlPageLinkRendererBegin(
@@ -24,10 +26,10 @@ class Hooks {
 						&$text, &$extraAttribs, &$query,
 						&$ret )
 	 	{
-			global $wgUser;
-			if ($wgUser->isSafeToLoad())
+			$user = RequestContext::getMain()->getUser();
+			if ($user->isSafeToLoad())
 			{
-				if ( $wgUser->isLoggedIn()) {
+				if ( $user->isRegistered()) {
 					return true;
 				}
 			}
@@ -58,7 +60,7 @@ class Hooks {
 			\User $user,
 			&$forOptions ) {
 
-			if ( $user->isLoggedIn()) {
+			if ( $user->isRegistered()) {
 					$confstr .= "!userKnown";
 			}
 			else {


### PR DESCRIPTION
* Replace global $wgUser by RequestContext::getUser() – use of global $wgUser is deprecated since MediaWiki 1.35
* Replace User::isLoggedIn() by User::isRegistered() – User::isLoggedIn() is deprecated since MediaWiki 1.36
* Update minimum MediaWiki version to 1.34 – User::isRegistered() was added in MediaWiki 1.34