### PR TITLE
Fix default value of $wgRemoveRedLinksAlsoLoggedInUsers

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -20,11 +20,12 @@
     "ParserOptionsRegister": "RemoveRedlinks::onParserOptionsRegister"
   },
   "config_prefix": "wg",
-	"config": {
-		"RemoveRedLinksAlsoLoggedInUsers": {
-			"value": false,
-			"description": "Remove red links also for logged-in users, instead of only for unregistered users"
-		}
+  "config": {
+    "RemoveRedLinksAlsoLoggedInUsers": {
+      "value": false,
+      "public": true,
+      "description": "Remove red links also for logged-in users, instead of only for unregistered users"
+    }
   },
-  "manifest_version": 1
+  "manifest_version": 2
 }


### PR DESCRIPTION
By setting the extension.json manifest to v1 instead of v2 in #13, the value of `$wgRemoveRedLinksAlsoLoggedInUsers` was an array containing two keys 'value' and 'description' (see below), which was equal to a value `true` instead of the "documented" value `false`, and since true by default **the links were never red even for logged-in users**.

Also, document the fact this parameter is public (i.e. not a secret) and avoid mixing tabs and spaces in extension.json.

```bash
php maintenance/run.php eval
> var_dump( $wgRemoveRedLinksAlsoLoggedInUsers );
array(2) {
  ["value"]=>
  bool(false)
  ["description"]=>
  string(81) "Remove red links also for logged-in users, instead of only for unregistered users"
}
```