### PR TITLE
Fix manifest version

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -26,5 +26,5 @@
 			"description": "Remove red links also for logged-in users, instead of only for unregistered users"
 		}
   },
-  "manifest_version": 1
+  "manifest_version": 2
 }


### PR DESCRIPTION
When manifest version 1 is used, it conflicts with the config values since they're formatted manifest version 2-style, leading to:

```php
Psy Shell v0.12.8 (PHP 8.2.28 — cli) by Justin Hileman
> $wgRemoveRedLinksAlsoLoggedInUsers
= [
    "value" => false,
    "description" => "Remove red links also for logged-in users, instead of only for unregistered users",
  ]
```

Which causes redlinks to also be removed for all logged-in users if the default is used, since the default is a truthy-value

Caused by c4533af1b0f7e89874360ba7da7fd7695c4b74d6